### PR TITLE
add optional pvc to postgres pod at /data

### DIFF
--- a/massdriver.yaml
+++ b/massdriver.yaml
@@ -1,19 +1,33 @@
 schema: draft-07
-name: postgres
+name: k8s-postgres-pod
 description: Postgres pod bundle to deploy onto Kubernetes in Massdriver.
-source_url: github.com/YOUR_ORG/postgres
+source_url: github.com/playlab-education/kubernetes-postgres-pod
 access: private
 type: infrastructure
+steps:
+  - path: src
+    provisioner: terraform
 
 params:
   required:
     - namespace
+    - storage_size
   properties:
     namespace:
       title: Kubernetes Namespace
       description: Application will be deployed into this namespace. If the namespace doesn't exist, it will be created.
       $ref: https://raw.githubusercontent.com/massdriver-cloud/artifact-definitions/main/definitions/types/k8s-resource-name.json
       default: default
+    storage_size:
+      title: Attached Volume Size (PVC)
+      description: The size of the attached volume (PVC). Enter `0` for no volume.
+      type: string
+      default: 1Gi
+    storage_class:
+      title: Storage Class
+      description: The storage class to use for the attached volume (PVC).
+      type: string
+      default: null
 
 connections:
   required:
@@ -25,4 +39,6 @@ connections:
 ui:
   ui:order:
     - namespace
+    - storage_size
+    - storage_class
     - '*'

--- a/src/_massdriver_variables.tf
+++ b/src/_massdriver_variables.tf
@@ -68,3 +68,11 @@ variable "md_metadata" {
 variable "namespace" {
   type = string
 }
+// Auto-generated variable declarations from massdriver.yaml
+variable "storage_class" {
+  type    = string
+  default = null
+}
+variable "storage_size" {
+  type = string
+}

--- a/src/chart/templates/deployment.yaml
+++ b/src/chart/templates/deployment.yaml
@@ -19,3 +19,15 @@ spec:
           env:
             - name: POSTGRES_PASSWORD
               value: password
+          volumeMounts:
+            - mountPath: /data
+              name: postgres-storage
+      volumes:
+        {{- if not (eq .Values.persistence.size "0") }}
+        - name: postgres-storage
+          persistentVolumeClaim:
+            claimName: {{ include "application.fullname" . }}-pvc
+        {{- else }}
+        - name: postgres-storage
+          emptyDir: {}
+        {{- end }}

--- a/src/chart/templates/pvc.yaml
+++ b/src/chart/templates/pvc.yaml
@@ -1,0 +1,18 @@
+{{- if not (eq .Values.persistence.size "0") }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "application.fullname" . }}-pvc
+  annotations:
+    debug.helm.sh/size: {{ .Values.persistence.size | quote }}
+    debug.helm.sh/raw-size: {{ printf "%#v" .Values.persistence.size }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+  {{- if .Values.persistence.storageClassName }}
+  storageClassName: {{ .Values.persistence.storageClassName }}
+  {{- end }}
+{{- end }}

--- a/src/chart/values.yaml
+++ b/src/chart/values.yaml
@@ -3,3 +3,7 @@ commonLabels: {}
 pod:
   annotations: {}
   labels: {}
+
+persistence:
+  size: 1Gi
+  storageClassName: null  # null means use cluster default

--- a/src/helm_values.tf
+++ b/src/helm_values.tf
@@ -1,5 +1,9 @@
 locals {
   helm_values = {
     commonLabels = var.md_metadata.default_tags
+    persistence = {
+      size = var.storage_size
+      storageClassName = var.storage_class
+    }
   }
 }


### PR DESCRIPTION
- allows you to optionally attach volume (disk space) to the postgres pod, configurable in the MD ux, which mounts on the pod at `/data`; you can also optionally specify the storage class or use the default for k8s cluster